### PR TITLE
Fixes formatting of subfields in the PageList

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.module
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.module
@@ -381,6 +381,7 @@ abstract class ProcessPageListRender extends Wire {
 
 			if($subfield && is_object($v)) {
 				if($v instanceof WireArray && count($v)) $v = $v->first();
+				$v->of(true);
 				$v = $v->get($subfield);
 
 			} else if(($field == 'created' || $field == 'modified') && ctype_digit("$v")) {


### PR DESCRIPTION
When defining fields to be displayed in the PageList for a specific template (pageLabelField), it is possible to set subfields (such as order.date). However, subfields are not formatted (e.g., dates are shown as timestamps). The proposed pull request sets output formatting on when fetching the subfield.